### PR TITLE
reduce memory usage of console_stderr event handler

### DIFF
--- a/colcon_output/event_handler/console_stderr.py
+++ b/colcon_output/event_handler/console_stderr.py
@@ -50,3 +50,4 @@ class ConsoleStderrEventHandler(EventHandlerExtensionPoint):
                         self._stderr_lines[job]).decode() + \
                     '---'
                 print(msg, file=sys.stderr, flush=True)
+                del self._stderr_lines[job]


### PR DESCRIPTION
By removing the already printed lines from the dictionary.

Discovered while implementing https://github.com/colcon/colcon-output/pull/29/files#diff-4ab7309c9a75a86010dccf1a52be78ccR60.