### PR TITLE
use RuntimeError to signal ENOSPC

### DIFF
--- a/test/spell_check.words
+++ b/test/spell_check.words
@@ -1,6 +1,7 @@
 apache
 colcon
 defaultdict
+enospc
 getpreferredencoding
 iterdir
 noqa
@@ -11,4 +12,5 @@ rtype
 scspell
 setuptools
 sigint
+stacktrace
 thomas


### PR DESCRIPTION
Together with colcon/colcon-core#347 avoids showing stacktraces when `ENOSPC` is signaled.