### PR TITLE
only prefix lines with the elapsed time in the streams.log

### DIFF
--- a/colcon_output/event_handler/log.py
+++ b/colcon_output/event_handler/log.py
@@ -109,19 +109,21 @@ class LogEventHandler(EventHandlerExtensionPoint):
             line = data.line
 
         if not isinstance(line, bytes):
-            # use the same encoding as the default for the opened file handle
+            # use the same encoding as the default for the opened file
             line = line.encode(encoding=locale.getpreferredencoding(False))
-
-        # prefix line with relative time
-        relative_time = time.monotonic() - self._start_times[job]
-        # use the same encoding as the default for the opened file handle
-        prefix = ('[%.3fs] ' % relative_time).encode(
-            encoding=locale.getpreferredencoding(False))
-        line = prefix + line
 
         base_path = get_log_directory(job)
         for filename in filenames:
             h = self._file_handles[base_path / filename]
+
+            if filename == ALL_STREAMS_LOG_FILENAME:
+                # prefix line with relative time
+                relative_time = time.monotonic() - self._start_times[job]
+                # use the same encoding as the default for the opened file
+                prefix = ('[%.3fs] ' % relative_time).encode(
+                    encoding=locale.getpreferredencoding(False))
+                h.write(prefix)
+
             h.write(line)
             try:
                 h.flush()


### PR DESCRIPTION
Follow up of #25.

The elapsed time prefix to each line in the log files is helpful for the user to know the point in time a line was printed. But in some cases the unaltered output is needed, e.g. to extract compiler warnings in Jenkins. In those cases the extra prefix is unexpected and confuses out-of-the-box software.

Therefore this PR removes the prefix from all log files but the `streams.log`. That allows to feed logs like `stdout_stderr.log` to tools like the Jenkins `warnings-ng` plugin while still providing users a complete log with timestamps on each line to introspect when certain output appeared and certain commands started / finished.