### PR TITLE
Reset _file_handle after closing.

### DIFF
--- a/colcon_output/event_handler/event_log.py
+++ b/colcon_output/event_handler/event_log.py
@@ -59,6 +59,7 @@ class EventLogEventHandler(EventHandlerExtensionPoint):
 
         if isinstance(data, EventReactorShutdown):
             self._file_handle.close()
+            self._file_handle = None
 
     def _init_log(self):
         # only create log once


### PR DESCRIPTION
In my CI script I subsequently call `colcon_core.command.main()` first with `build`, then with `test` in the same python script. As the event handler `_file_handle` is not reset in between the calls the `_file_handle` is closed but not initialized again, so it tries to write to a closed file. 

This MR resets the `_file_handle` after closing the file, such that a subsequent call of `__call__` will open the file again.

Let me know if this is not the intended way of using the event handler.