### PR TITLE
[BUGFIX] Fix a possible None argument that makes it fail when no logs are generated

### DIFF
--- a/colcon_output/event_handler/log.py
+++ b/colcon_output/event_handler/log.py
@@ -2,7 +2,6 @@
 # Licensed under the Apache License, Version 2.0
 
 import copy
-from email.mime import base
 import errno
 import locale
 import os
@@ -78,7 +77,8 @@ class LogEventHandler(EventHandlerExtensionPoint):
             self._start_times[job] = time.monotonic()
 
         if isinstance(data, JobEnded):
-            # Skip if the log path is /dev/null and/or is unable to get directory
+            # Skip if the log path is /dev/null
+            # and/or is unable to get directory
             if get_log_path() is None:
                 return
             base_path = get_log_directory(job)

--- a/colcon_output/event_handler/log.py
+++ b/colcon_output/event_handler/log.py
@@ -78,9 +78,7 @@ class LogEventHandler(EventHandlerExtensionPoint):
 
         if isinstance(data, JobEnded):
             # Skip if the log path is /dev/null
-            # and/or is unable to get directory
-            if get_log_path() is None:
-                return
+            # => is unable to get directory
             base_path = get_log_directory(job)
             if base_path is None:
                 return
@@ -152,19 +150,16 @@ class LogEventHandler(EventHandlerExtensionPoint):
         if job in self._jobs:
             return True
 
-        log_path = get_log_path()
-        if log_path is None:
+        # Get directory
+        # If this fails, the log directory is /dev/null
+        # so function must return with negative result
+        base_path = get_log_directory(job)
+        if base_path is None:
             return False
 
         self._jobs.add(job)
 
         create_log_path(self.context.args.verb_name)
-
-        # Get directory and return false if fails
-        # (this is redundant with previous get_log_path call, but just in case)
-        base_path = get_log_directory(job)
-        if base_path is None:
-            return False
 
         os.makedirs(str(base_path), exist_ok=True)
         for filename in all_log_filenames:
@@ -181,6 +176,6 @@ def get_log_directory(job):
     :rtype: Path
     """
     log_path = get_log_path()
-    if log_path is None or job.identifier is None:
+    if log_path is None:
         return None
     return log_path / job.identifier

--- a/colcon_output/event_handler/log.py
+++ b/colcon_output/event_handler/log.py
@@ -166,4 +166,7 @@ def get_log_directory(job):
     :param job: The job
     :rtype: Path
     """
-    return get_log_path() / job.identifier
+    log_path = get_log_path()
+    if log_path is None or job.identifier is None:
+        return None
+    return log_path / job.identifier


### PR DESCRIPTION
Please @cottsay , could you review this simple bugfix? And add it in future colcon versions if possible.

## BUG
In function `event_handler::get_log_directory`, `get_log_path` is called without checking the return.

This leads to a failure with this message:
```
ERROR:colcon.colcon_core.event_reactor:Exception in event handler extension 'log': unsupported operand type(s) for /: 'NoneType' and 'str'
Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/colcon_core/event_reactor.py", line 78, in _notify_observers
    retval = observer(event)
  File "/usr/lib/python3/dist-packages/colcon_output/event_handler/log.py", line 80, in __call__
    base_path = get_log_directory(job)
  File "/usr/lib/python3/dist-packages/colcon_output/event_handler/log.py", line 166, in get_log_directory
    return get_log_path() / job.identifier
TypeError: unsupported operand type(s) for /: 'NoneType' and 'str'
```

## SOLUTION
check the function return before calling `/` operator, and thus avoid the error.

## SCENARIO
This has arised in my scenario when I set option `--log-base /dev/null` so no logs are generated.
This should work as expected in documentation: https://colcon.readthedocs.io/en/released/reference/global-arguments.html